### PR TITLE
Dawson

### DIFF
--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -73,10 +73,10 @@
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC8</languageToolchain>
         <languageToolchainVersion>2.00</languageToolchainVersion>
-        <platform>2</platform>
+        <platform>3</platform>
       </toolsSet>
       <packs>
-        <pack name="PIC12-16F1xxx_DFP" vendor="Microchip" version="0.1.7"/>
+        <pack name="PIC12-16F1xxx_DFP" vendor="Microchip" version="1.0.21"/>
       </packs>
       <compileType>
         <linkerTool>

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -12,6 +12,20 @@
             <asminc-extensions/>
             <sourceEncoding>ISO-8859-1</sourceEncoding>
             <make-dep-projects/>
+            <sourceRootList>
+                <sourceRootElem>cjson</sourceRootElem>
+                <sourceRootElem>microjson</sourceRootElem>
+                <sourceRootElem>canlib/mcp2515</sourceRootElem>
+            </sourceRootList>
+            <confList>
+                <confElem>
+                    <name>default</name>
+                    <type>2</type>
+                </confElem>
+            </confList>
+            <formatting>
+                <project-formatting-style>false</project-formatting-style>
+            </formatting>
         </data>
     </configuration>
 </project>

--- a/usb_app.c
+++ b/usb_app.c
@@ -52,6 +52,23 @@ bool compare_can_msg(const can_msg_t *msg1, const can_msg_t *msg2) {
     return true;
 }
 
+uint8_t debug_level_message(const can_msg_t *msg) {
+    return (msg->sid % 5);
+}
+uint8_t allow_debug_messages() {// was: allow_sensor_messages() --> not sure if that was intended
+    return 2;
+}
+uint8_t max_debug_level() {
+    return 2;
+}
+
+bool is_sensor_data(const can_msg_t *msg) {
+    return (msg->sid == 0xAA);
+}
+bool allow_sensor_messages() { 
+    return false;
+}
+
 uint8_t usb_app_report_can_msg(const can_msg_t *msg) {
     char temp_buffer[3*7+9];
     static can_msg_t last_received_message;
@@ -62,6 +79,14 @@ uint8_t usb_app_report_can_msg(const can_msg_t *msg) {
         'C', 'D', 'E', 'F'
     };
     
+    if(is_sensor_data(msg)) { 
+        if(!allow_sensor_messages()) {
+            return 0;
+        }
+    }
+    if(!(debug_level_message(msg) <= max_debug_level())) {
+        return 0;
+    }
     if(compare_can_msg(msg, &last_received_message)) {
         temp_buffer[0] = '.';
         temp_buffer[1] = '\0';

--- a/usb_app.c
+++ b/usb_app.c
@@ -37,6 +37,7 @@ void usb_app_heartbeat(void)
     CDCTxService();
 }
 
+// Compares 2 messages (and therefore all of their elements)
 bool compare_can_msg(const can_msg_t *msg1, const can_msg_t *msg2) {
     if(msg1->data_len != msg2->data_len) {
         return false;
@@ -55,9 +56,7 @@ bool compare_can_msg(const can_msg_t *msg1, const can_msg_t *msg2) {
 uint8_t debug_level_message(const can_msg_t *msg) {
     return (msg->sid % 5);
 }
-uint8_t allow_debug_messages() {// was: allow_sensor_messages() --> not sure if that was intended
-    return 2;
-}
+
 uint8_t max_debug_level() {
     return 2;
 }
@@ -65,6 +64,7 @@ uint8_t max_debug_level() {
 bool is_sensor_data(const can_msg_t *msg) {
     return (msg->sid == 0xAA);
 }
+
 bool allow_sensor_messages() { 
     return false;
 }
@@ -79,20 +79,37 @@ uint8_t usb_app_report_can_msg(const can_msg_t *msg) {
         'C', 'D', 'E', 'F'
     };
     
+    // Check for if the incoming message is a sensor data
+    // If message is sensor data, check for if the sensor messages is allowed to be printed
+    // If sensor messages are not allowed to be printed, exits function early
+    // If sensor messages allowed, it prints the message normally
     if(is_sensor_data(msg)) { 
         if(!allow_sensor_messages()) {
             return 0;
         }
     }
-    if(!(debug_level_message(msg) <= max_debug_level())) {
+    
+    // Check for if the message coming in has a sid value > max_debug_level
+    // If true, exits function early, otherwise it prints the message normally
+    if(debug_level_message(msg) > max_debug_level()) {
         return 0;
     }
+    
+    // Checks if the last message is the same as the new message coming in
+    // If true, prints a dot and ends the function
+    // Otherwise, prints the message normally
     if(compare_can_msg(msg, &last_received_message)) {
         temp_buffer[0] = '.';
         temp_buffer[1] = '\0';
     }
     else {
         last_received_message = *msg;
+        // temp_buffer is the character array of the message that gets printed
+        // out when usb_app_report_can_msg is called on.
+        // The first 3 characters are the sid of the input message followed by a ':'
+        // The next 2 characters are elements of the data array apart of the input message followed by a ','
+        // The next 2 characters are for formatting output
+        // The last character is used to end the string made from temp_buffer
         temp_buffer[0] = hex_lookup_table[(msg->sid >> 8) & 0xf];
         temp_buffer[1] = hex_lookup_table[(msg->sid >> 4) & 0xf];
         temp_buffer[2] = hex_lookup_table[msg->sid & 0xf];
@@ -108,6 +125,8 @@ uint8_t usb_app_report_can_msg(const can_msg_t *msg) {
         temp_buffer[3*i + 7] = '\r';
         temp_buffer[3*i + 8] = '\0';
     }
+    
+    // Writes temp_buffer to a string
     if(usb_app_write_string(temp_buffer, strlen(temp_buffer))) {
         return 1;
     }


### PR DESCRIPTION
The first change filters out repeated messages coming from the usb board. 
- When there is a repeated message, the usb_app_report_can_msg function prints a '.' (dot) in its place.

The second change covers filtering for sensor and debug messages. 
- When there is a sensor messages: usb_app_report_can_msg checks if the message coming in has the same sid as the one in is_senor_data. The function will end early and not print out the message if is_senor_data returns true and allow_sensor_messages returns false, otherwise it prints the message normally.
- When there is debug messages: usb_app_report_can_msg function ends if debug_level_message(msg) is not <= max_debug_level() otherwise it prints the message normally.