### PR TITLE
Fix compiler error when using xc8v2.00

### DIFF
--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configurationDescriptor version="62">
+<configurationDescriptor version="65">
   <logicalFolder name="root" displayName="root" projectFiles="true">
     <logicalFolder name="f1" displayName="canlib" projectFiles="true">
       <itemPath>canlib/can.h</itemPath>
@@ -81,9 +81,12 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC8</languageToolchain>
-        <languageToolchainVersion>1.44</languageToolchainVersion>
-        <platform>4</platform>
+        <languageToolchainVersion>2.00</languageToolchainVersion>
+        <platform>2</platform>
       </toolsSet>
+      <packs>
+        <pack name="PIC12-16F1xxx_DFP" vendor="Microchip" version="0.1.7"/>
+      </packs>
       <compileType>
         <linkerTool>
           <linkerLibItems>


### PR DESCRIPTION
Rev canlib version to the version with the fix, and update the compiler
version in the configurations.xml file.