### PR TITLE
fix canlib submodule to point at waterloo-rocketry/canlib.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "canlib"]
 	path = canlib
-	url = https://github.com/amihaila/canlib.git
+	url = https://github.com/waterloo-rocketry/canlib.git


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/cansw_usb/9)
<!-- Reviewable:end -->
