### PR TITLE
Add astyle formatting script

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -8,8 +8,8 @@
 # Documentation for AStyle and a description of what all options do
 # is at http://astyle.sourceforge.net/astyle.html.
 
-# Put opening braces on a new line after the expression, like this:
-#   if (x == 1)
+# Put opening braces on a new line after function headers, like this:
+#   int sqr(x)
 #   {
 style=kr
 indent=spaces=4
@@ -18,8 +18,7 @@ indent=spaces=4
 indent-switches
 
 # In do-while loops, while appears on same line as the closing bracket:
-#   } while
-#   {
+#   } while (x > 10);
 attach-closing-while
 
 # a=2 becomes a = 2

--- a/.astylerc
+++ b/.astylerc
@@ -1,0 +1,57 @@
+### AStyle configuration options ###
+
+# Waterloo Rocketry does not enforce a team-wide style guide, but we do
+# ask that all codebases remain internally consistent. If you change
+# the options in this file, please rerun the formatter on all source
+# files using `./format.sh -a`
+
+# Documentation for AStyle and a description of what all options do
+# is at http://astyle.sourceforge.net/astyle.html.
+
+# Put opening braces on a new line after the expression, like this:
+#   if (x == 1)
+#   {
+style=kr
+indent=spaces=4
+
+# Indent case statements from parent switch
+indent-switches
+
+# In do-while loops, while appears on same line as the closing bracket:
+#   } while
+#   {
+attach-closing-while
+
+# a=2 becomes a = 2
+pad-oper
+
+# foo(a,b,c) becomes foo(a, b, c)
+pad-comma
+
+# if(x) becomes if (x). Same for while, for, etc.
+pad-header
+
+# When declaring pointers, do "char *c", not "char* c". This is to
+# reduce ambiguity. "char* a, b, c" looks like it's declaring 3 char
+# pointers, but it's not.
+align-pointer=name
+
+# "if (x) { y(); }" should be on 3 lines, not 1
+break-one-line-headers
+
+# 100 characters is usually enough for any reasonable codebase
+max-code-length=100
+
+# When splitting a large conditional across multiple lines, insert the
+# linebreak after the || or && rather than before it.
+break-after-logical
+
+# Don't excessively indent headers broken into multiple lines:
+#
+#   if (a < b || c > d)
+#
+#   becomes
+#
+#   if (a < b
+#       || c > d)
+min-conditional-indent=0

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage()
+{
+  echo "Usage: $0 [-h] [-a/--all]"
+  echo
+  echo "arguments:"
+  echo " -a, --all     format all files in the repo"
+  echo " -h, --help    show this help message and exit"
+  exit 2
+}
+
+if ! type astyle &> /dev/null
+then
+    echo "Error: astyle is not installed or is not on the PATH."
+    echo "Please install astyle to use this tool."
+    exit 1
+fi
+
+WORKSPACE_DIR=$(git rev-parse --show-toplevel)
+cd "$WORKSPACE_DIR"
+
+if [ "$#" -eq 0 ] ; then
+    ALL_FILES=$({ git ls-files -o --exclude-standard && git diff --diff-filter=d --name-only master; })
+elif [ "$1" = "-a" ] || [ "$1" = "--all" ] ; then
+    ALL_FILES=$({ git ls-files -cmo --exclude-standard; })
+else
+    usage
+fi
+
+FILES=$(echo "$ALL_FILES" | grep -v 'mcc_generated_files' | grep -E '\.c$|\.h$|\.cpp$|\.hpp$|\.cc$|\.hh$|\.ino$')
+
+if [ ! -z "$FILES" ]
+then
+    astyle --project=.astylerc -n $FILES
+fi

--- a/main.c
+++ b/main.c
@@ -11,7 +11,8 @@
 
 #define BLINK_LEDS(before_time_off, after_time_on) do{ __delay_ms(before_time_off); LED_1_ON(); LED_2_ON(); __delay_ms(after_time_on); LED_1_OFF(); LED_2_OFF();}while(0)
 
-static void visual_heartbeat(void) {
+static void visual_heartbeat(void)
+{
     static bool led_on = false;
     if (led_on) {
         LED_1_OFF();
@@ -45,7 +46,7 @@ void main(void)
 
     BLINK_LEDS(50, 300);
 
-    while(!usb_app_write_string("Finished CAN setup. Waiting for messages.\n\r", 42))
+    while (!usb_app_write_string("Finished CAN setup. Waiting for messages.\n\r", 42))
         usb_app_heartbeat();
 
     // When using interrupts, you need to set the Global and Peripheral Interrupt Enable bits
@@ -63,10 +64,9 @@ void main(void)
     msg_send.sid = 0x7ef;
     msg_send.data_len = 2;
 
-    while (1)
-    {
+    while (1) {
         // if CAN module fires interrupt pin, receive a message
-        if(!PORTAbits.RA5) {
+        if (!PORTAbits.RA5) {
             can_msg_t rcv;
             if (mcp_can_receive(&rcv)) {
                 usb_app_report_can_msg(&rcv);
@@ -77,7 +77,7 @@ void main(void)
         // Add your application code
         usb_app_heartbeat();
 
-        if(usb_app_available_bytes() != 0) {
+        if (usb_app_available_bytes() != 0) {
             char input_string[64];
             usb_app_read_bytes(input_string, sizeof(input_string));
             parse_usb_string(input_string);

--- a/spi.c
+++ b/spi.c
@@ -2,7 +2,8 @@
 #include <stdint.h>
 #include <xc.h>
 
-void spi_init() {
+void spi_init()
+{
     //mark SCL as output
     TRISCbits.TRISC0 = 0;
     //mark MISO as input
@@ -16,29 +17,32 @@ void spi_init() {
     SSPSTAT = 0b10000000;
     SSPCON1 = 0b00110010;
     SSPCON2 = 0b00000000;
-    
+
 }
 
-void spi_write(uint8_t data) {
+void spi_write(uint8_t data)
+{
     uint8_t temp = SSPBUF;
     PIR1bits.SSP1IF = 0;
     SSPCONbits.WCOL = 0;
     SSPBUF = data;
-    while(!PIR1bits.SSP1IF) {};
+    while (!PIR1bits.SSP1IF) {};
 }
 
-uint8_t spi_read(void) {
+uint8_t spi_read(void)
+{
     //read the SSPBUF so it doesn't yell at you
     uint8_t temp = SSPBUF;
     PIR1bits.SSP1IF = 0;
     //clock 0 onto the pins
     SSPBUF = 0;
-    while(!PIR1bits.SSP1IF) {}
+    while (!PIR1bits.SSP1IF) {}
     return SSPBUF;
 }
 
-void cs_drive(uint8_t state) {
-    if(state)
+void cs_drive(uint8_t state)
+{
+    if (state)
         LATC |= (1 << 3);
     else
         LATC &= ~(1 << 3);

--- a/usb_app.c
+++ b/usb_app.c
@@ -57,7 +57,7 @@ bool compare_can_msg(const can_msg_t *msg1, const can_msg_t *msg2)
 uint8_t usb_app_report_can_msg(const can_msg_t *msg)
 {
     //length for 1 byte ("XX,") * number of bytes-1 + extras and last byte
-    char temp_buffer[3 * 7 + 10]; 
+    char temp_buffer[3 * 7 + 10];
     static can_msg_t last_received_message;
     const char hex_lookup_table[16] = {
         '0', '1', '2', '3',

--- a/usb_app.h
+++ b/usb_app.h
@@ -10,8 +10,8 @@ void usb_app_heartbeat(void);
 uint8_t usb_app_report_can_msg(const can_msg_t *msg);
 
 uint8_t usb_app_available_bytes(void);
-uint8_t usb_app_read_bytes(char* buffer, uint8_t len);
+uint8_t usb_app_read_bytes(char *buffer, uint8_t len);
 
-bool usb_app_write_string(char* buffer, uint8_t len);
+bool usb_app_write_string(char *buffer, uint8_t len);
 
 #endif


### PR DESCRIPTION
A little late in coming, but better than never, right?

This PR adds the long-awaited C/C++ formatting script using AStyle,
everyone's second-favourite C formatter. We provide a `.astylerc` largely
based on the one Aaron originally used with minor modifications (mostly
commenting changes, but I did bump the line length to 100 characters).

The script was run on all of the current files in the repo (except for MCC
generated files), so you can see a few examples of the changes that result.
If y'all don't like the settings, we can tweak them.

We should be able to copy the script and rc directly to every other C/C++
project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/cansw_usb/10)
<!-- Reviewable:end -->
